### PR TITLE
Add keep_all_keypoints setting to preserve full graph schema in predictions

### DIFF
--- a/serve/custom_settings.yaml
+++ b/serve/custom_settings.yaml
@@ -11,6 +11,13 @@ max_det: 300
 agnostic_nms: False
 # point confidence threshold (for pose estimation)
 point_threshold: 0.1
+# for pose estimation: when true, every keypoint declared in the model's graph
+# template is always included in the prediction; points scoring below
+# "point_threshold" are kept but marked disabled/not-visible instead of being
+# removed from the graph. This matches the semantics of a manually annotated
+# keypoint that was hidden (Ctrl) rather than deleted, so predictions keep the
+# same node set as your training data.
+keep_all_keypoints: false
 # IoU threshold to filter out predictions that significantly overlap with ground truth objects
 # (the greater the value, the fewer predictions will remain)
 # If the value is 0.0, no filtering will be done

--- a/serve/src/keypoints_confidence.py
+++ b/serve/src/keypoints_confidence.py
@@ -1,0 +1,40 @@
+from typing import List, Sequence, Tuple
+
+
+def split_keypoints_by_confidence(
+    point_labels: Sequence[str],
+    coordinates: Sequence[Tuple[float, float]],
+    scores: Sequence[float],
+    point_threshold: float,
+    keep_all_keypoints: bool,
+) -> Tuple[List[str], List[Tuple[float, float]], List[bool]]:
+    """
+    Decide which template keypoints to emit in a prediction, and which of those should
+    be marked disabled.
+
+    A point scoring below ``point_threshold`` is dropped entirely, unless
+    ``keep_all_keypoints`` is set — in that case every point is kept, and the
+    low-confidence ones are flagged disabled instead of being removed from the graph.
+    This preserves the same node set as manually annotated ground truth, where a
+    not-visible keypoint stays in the graph as a disabled node rather than being
+    deleted.
+
+    :return: three equal-length lists (labels, coordinates, disabled) to build a
+        ``PredictionKeypoints`` DTO from.
+    """
+    labels, coords, disabled = [], [], []
+    for label, coordinate, score in zip(point_labels, coordinates, scores):
+        if score >= point_threshold:
+            labels.append(label)
+            coords.append(coordinate)
+            disabled.append(False)
+        elif keep_all_keypoints:
+            labels.append(label)
+            coords.append(coordinate)
+            disabled.append(True)
+    return labels, coords, disabled
+
+
+def count_visible(disabled: Sequence[bool]) -> int:
+    """Number of entries in ``disabled`` that are False (i.e. visible/enabled points)."""
+    return sum(1 for is_disabled in disabled if not is_disabled)

--- a/serve/src/keypoints_confidence.py
+++ b/serve/src/keypoints_confidence.py
@@ -1,38 +1,44 @@
 from typing import List, Sequence, Tuple
 
 
-def split_keypoints_by_confidence(
-    point_labels: Sequence[str],
-    coordinates: Sequence[Tuple[float, float]],
+def select_visible_indices(
     scores: Sequence[float],
     point_threshold: float,
     keep_all_keypoints: bool,
-) -> Tuple[List[str], List[Tuple[float, float]], List[bool]]:
+) -> Tuple[List[int], List[bool]]:
     """
-    Decide which template keypoints to emit in a prediction, and which of those should
-    be marked disabled.
+    Decide which keypoints to emit in a prediction, and which of those should be
+    marked disabled -- without touching coordinates.
 
     A point scoring below ``point_threshold`` is dropped entirely, unless
-    ``keep_all_keypoints`` is set — in that case every point is kept, and the
+    ``keep_all_keypoints`` is set -- in that case every point is kept, and the
     low-confidence ones are flagged disabled instead of being removed from the graph.
     This preserves the same node set as manually annotated ground truth, where a
     not-visible keypoint stays in the graph as a disabled node rather than being
     deleted.
 
-    :return: three equal-length lists (labels, coordinates, disabled) to build a
-        ``PredictionKeypoints`` DTO from.
+    Deliberately only returns indices/flags rather than filtering coordinates
+    directly: coordinate extraction can involve a GPU->CPU sync (``.cpu().numpy()``)
+    per point, so callers should only pay that cost for points that are actually
+    kept, exactly as before this option existed.
+
+    :param scores: confidence score per keypoint, in template order.
+    :param point_threshold: minimum score for a point to count as visible.
+    :param keep_all_keypoints: if True, keep every point (flagging low-confidence
+        ones as disabled) instead of dropping them.
+    :return: ``(indices, disabled)`` -- same length, in ascending/original order.
+        ``indices`` are positions into ``scores`` (and any other same-length,
+        same-order per-point sequence, e.g. labels/coordinates) that should be kept.
     """
-    labels, coords, disabled = [], [], []
-    for label, coordinate, score in zip(point_labels, coordinates, scores):
+    indices, disabled = [], []
+    for i, score in enumerate(scores):
         if score >= point_threshold:
-            labels.append(label)
-            coords.append(coordinate)
+            indices.append(i)
             disabled.append(False)
         elif keep_all_keypoints:
-            labels.append(label)
-            coords.append(coordinate)
+            indices.append(i)
             disabled.append(True)
-    return labels, coords, disabled
+    return indices, disabled
 
 
 def count_visible(disabled: Sequence[bool]) -> int:

--- a/serve/src/yolov8.py
+++ b/serve/src/yolov8.py
@@ -40,6 +40,7 @@ from supervisely.nn.prediction_dto import (
 )
 
 from supervisely.nn.artifacts.yolov8 import YOLOv8
+from src.keypoints_confidence import count_visible, split_keypoints_by_confidence
 from src.keypoints_template import dict_to_template, human_template
 from src.models import yolov8_models
 import src.workflow as w
@@ -360,10 +361,12 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                 raise KeyError(
                     f"Class {dto.class_name} not found in model classes {self.get_classes()}"
                 )
+            disabled_flags = getattr(dto, "disabled", None)
             nodes = []
-            for label, coordinate in zip(dto.labels, dto.coordinates):
+            for i, (node_label, coordinate) in enumerate(zip(dto.labels, dto.coordinates)):
                 x, y = coordinate
-                nodes.append(sly.Node(label=label, row=y, col=x))
+                is_disabled = bool(disabled_flags[i]) if disabled_flags is not None else False
+                nodes.append(sly.Node(label=node_label, row=y, col=x, disabled=is_disabled))
             label = sly.Label(sly.GraphNodes(nodes), obj_class)
         return label
 
@@ -407,6 +410,11 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
             keypoints_data = prediction.keypoints.data
             image_shape = prediction.orig_shape
             point_threshold = settings.get("point_threshold", 0.1)
+            # when set, every keypoint declared in the template is always emitted;
+            # points scoring below `point_threshold` are kept but marked disabled
+            # instead of being dropped from the graph, matching the semantics of a
+            # manually annotated (Ctrl-hidden) not-visible keypoint.
+            keep_all_keypoints = settings.get("keep_all_keypoints", False)
             if self.class_names == [
                 "person_bbox",
                 "person",
@@ -419,38 +427,56 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                     if bbox is None:
                         continue
                     confidence, cls_index = float(box[4]), int(box[5])
-                    included_labels, included_point_coordinates = [], []
+                    included_labels, included_point_coordinates, included_disabled = (
+                        [],
+                        [],
+                        [],
+                    )
                     if keypoints_data.shape[-1] == 3:
                         point_coordinates, point_scores = (
                             keypoints[:, :2],
                             keypoints[:, 2],
                         )
+                        # the "fictive" placeholder is not a real template node and is
+                        # never emitted, regardless of `keep_all_keypoints`
+                        real_labels, real_coordinates, real_scores = [], [], []
                         for j, (point_coordinate, point_score) in enumerate(
                             zip(point_coordinates, point_scores)
                         ):
-                            if (
-                                point_score >= point_threshold
-                                and point_labels[j] != "fictive"
-                            ):
-                                included_labels.append(point_labels[j])
-                                included_point_coordinates.append(
-                                    point_coordinate.cpu().numpy()
-                                )
+                            if point_labels[j] == "fictive":
+                                continue
+                            real_labels.append(point_labels[j])
+                            real_coordinates.append(point_coordinate.cpu().numpy())
+                            real_scores.append(float(point_score))
+                        (
+                            included_labels,
+                            included_point_coordinates,
+                            included_disabled,
+                        ) = split_keypoints_by_confidence(
+                            real_labels,
+                            real_coordinates,
+                            real_scores,
+                            point_threshold,
+                            keep_all_keypoints,
+                        )
                     elif keypoints_data.shape[-1] == 2:
+                        # no per-point confidence available, so there is nothing to
+                        # threshold on: always include every point, never disabled
                         for j, point_coordinate in enumerate(keypoints):
                             included_labels.append(point_labels[j])
                             included_point_coordinates.append(
                                 point_coordinate.cpu().numpy()
                             )
-                    if len(included_labels) > 1:
+                            included_disabled.append(False)
+                    if count_visible(included_disabled) > 1:
                         kpt_class_name = self.general_class_names[cls_index]
-                        dtos.append(
-                            sly.nn.PredictionKeypoints(
-                                kpt_class_name,
-                                included_labels,
-                                included_point_coordinates,
-                            )
+                        kpt_dto = sly.nn.PredictionKeypoints(
+                            kpt_class_name,
+                            included_labels,
+                            included_point_coordinates,
                         )
+                        kpt_dto.disabled = included_disabled
+                        dtos.append(kpt_dto)
                         bbox_class_name = self.general_class_names[cls_index] + "_bbox"
                         dtos.append(PredictionBBox(bbox_class_name, bbox, confidence))
             else:
@@ -469,24 +495,31 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                         node["label"] for node in keypoints_template["nodes"].values()
                     ]
                     n_label2point = self.node_label_to_point(keypoints)
-                    included_labels, included_point_coordinates = [], []
-                    for j, node_label in enumerate(node_labels):
+                    node_coordinates, node_scores = [], []
+                    for node_label in node_labels:
                         kpt = n_label2point[node_label]
-                        point_coordinate, point_score = kpt[:2], kpt[2]
-                        if point_score >= point_threshold:
-                            included_labels.append(point_labels[j])
-                            included_point_coordinates.append(
-                                point_coordinate.cpu().numpy()
-                            )
-                    if len(included_labels) > 1:
+                        node_coordinates.append(kpt[:2].cpu().numpy())
+                        node_scores.append(float(kpt[2]))
+                    (
+                        included_labels,
+                        included_point_coordinates,
+                        included_disabled,
+                    ) = split_keypoints_by_confidence(
+                        point_labels,
+                        node_coordinates,
+                        node_scores,
+                        point_threshold,
+                        keep_all_keypoints,
+                    )
+                    if count_visible(included_disabled) > 1:
                         kpt_class_name = self.general_class_names[cls_index]
-                        dtos.append(
-                            sly.nn.PredictionKeypoints(
-                                kpt_class_name,
-                                included_labels,
-                                included_point_coordinates,
-                            )
+                        kpt_dto = sly.nn.PredictionKeypoints(
+                            kpt_class_name,
+                            included_labels,
+                            included_point_coordinates,
                         )
+                        kpt_dto.disabled = included_disabled
+                        dtos.append(kpt_dto)
                         bbox_class_name = self.general_class_names[cls_index] + "_bbox"
                         dtos.append(PredictionBBox(bbox_class_name, bbox, confidence))
         return dtos

--- a/serve/src/yolov8.py
+++ b/serve/src/yolov8.py
@@ -40,7 +40,7 @@ from supervisely.nn.prediction_dto import (
 )
 
 from supervisely.nn.artifacts.yolov8 import YOLOv8
-from src.keypoints_confidence import count_visible, split_keypoints_by_confidence
+from src.keypoints_confidence import count_visible, select_visible_indices
 from src.keypoints_template import dict_to_template, human_template
 from src.models import yolov8_models
 import src.workflow as w
@@ -361,11 +361,11 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                 raise KeyError(
                     f"Class {dto.class_name} not found in model classes {self.get_classes()}"
                 )
-            disabled_flags = getattr(dto, "disabled", None)
+            disabled_flags = getattr(dto, "disabled", None) or []
             nodes = []
             for i, (node_label, coordinate) in enumerate(zip(dto.labels, dto.coordinates)):
                 x, y = coordinate
-                is_disabled = bool(disabled_flags[i]) if disabled_flags is not None else False
+                is_disabled = bool(disabled_flags[i]) if i < len(disabled_flags) else False
                 nodes.append(sly.Node(label=node_label, row=y, col=x, disabled=is_disabled))
             label = sly.Label(sly.GraphNodes(nodes), obj_class)
         return label
@@ -439,26 +439,24 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                         )
                         # the "fictive" placeholder is not a real template node and is
                         # never emitted, regardless of `keep_all_keypoints`
-                        real_labels, real_coordinates, real_scores = [], [], []
-                        for j, (point_coordinate, point_score) in enumerate(
-                            zip(point_coordinates, point_scores)
-                        ):
-                            if point_labels[j] == "fictive":
-                                continue
-                            real_labels.append(point_labels[j])
-                            real_coordinates.append(point_coordinate.cpu().numpy())
-                            real_scores.append(float(point_score))
-                        (
-                            included_labels,
-                            included_point_coordinates,
-                            included_disabled,
-                        ) = split_keypoints_by_confidence(
-                            real_labels,
-                            real_coordinates,
-                            real_scores,
-                            point_threshold,
-                            keep_all_keypoints,
+                        real_indices = [
+                            j
+                            for j in range(len(point_coordinates))
+                            if point_labels[j] != "fictive"
+                        ]
+                        real_scores = [float(point_scores[j]) for j in real_indices]
+                        chosen, included_disabled = select_visible_indices(
+                            real_scores, point_threshold, keep_all_keypoints
                         )
+                        # coordinates are only converted off-GPU for points that are
+                        # actually kept, same as before this setting existed
+                        included_labels = [
+                            point_labels[real_indices[k]] for k in chosen
+                        ]
+                        included_point_coordinates = [
+                            point_coordinates[real_indices[k]].cpu().numpy()
+                            for k in chosen
+                        ]
                     elif keypoints_data.shape[-1] == 2:
                         # no per-point confidence available, so there is nothing to
                         # threshold on: always include every point, never disabled
@@ -495,22 +493,18 @@ class YOLOv8Model(sly.nn.inference.ObjectDetection):
                         node["label"] for node in keypoints_template["nodes"].values()
                     ]
                     n_label2point = self.node_label_to_point(keypoints)
-                    node_coordinates, node_scores = [], []
-                    for node_label in node_labels:
-                        kpt = n_label2point[node_label]
-                        node_coordinates.append(kpt[:2].cpu().numpy())
-                        node_scores.append(float(kpt[2]))
-                    (
-                        included_labels,
-                        included_point_coordinates,
-                        included_disabled,
-                    ) = split_keypoints_by_confidence(
-                        point_labels,
-                        node_coordinates,
-                        node_scores,
-                        point_threshold,
-                        keep_all_keypoints,
+                    node_scores = [
+                        float(n_label2point[node_label][2]) for node_label in node_labels
+                    ]
+                    chosen, included_disabled = select_visible_indices(
+                        node_scores, point_threshold, keep_all_keypoints
                     )
+                    # coordinates are only converted off-GPU for points that are
+                    # actually kept, same as before this setting existed
+                    included_labels = [point_labels[i] for i in chosen]
+                    included_point_coordinates = [
+                        n_label2point[node_labels[i]][:2].cpu().numpy() for i in chosen
+                    ]
                     if count_visible(included_disabled) > 1:
                         kpt_class_name = self.general_class_names[cls_index]
                         kpt_dto = sly.nn.PredictionKeypoints(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# tests import "src.*" modules the same way the serve app itself does
+# (see tests/deploy_and_infer.py), so serve/ needs to be on sys.path.
+serve_src_path = str(Path(__file__).parents[1] / "serve")
+if serve_src_path not in sys.path:
+    sys.path.append(serve_src_path)

--- a/tests/test_keep_all_keypoints_label.py
+++ b/tests/test_keep_all_keypoints_label.py
@@ -1,0 +1,161 @@
+"""
+SDK-level tests for the "keep_all_keypoints" feature: verifies that a
+PredictionKeypoints DTO carrying a `.disabled` list is turned into a GraphNodes Label
+with the correct per-node `disabled` flag, that this validates against a project meta
+template requiring all nodes, and that the disabled flag round-trips through
+to_json/from_json exactly like a manually-hidden (Ctrl) keypoint would.
+
+Only needs the `supervisely` package installed — no ultralytics/torch/cv2, no running
+model, no GUI. This intentionally mirrors (rather than imports) the small
+PredictionKeypoints -> GraphNodes conversion in YOLOv8Model._create_label
+(serve/src/yolov8.py), since importing that module pulls in the full ultralytics/torch
+stack that this feature's core logic does not actually depend on.
+
+Run with:  python -m pytest tests/test_keep_all_keypoints_label.py -v
+"""
+
+from typing import List, Optional
+
+import pytest
+import supervisely as sly
+from supervisely.nn.prediction_dto import PredictionKeypoints
+
+# The exact 24 pig-anatomy keypoint labels from the reported customer template
+# (see investigation.md), used here as a realistic, non-trivial node set.
+PIG_TEMPLATE_LABELS = [
+    "nose_end", "belly_bottom", "right_ear_base", "left_ear_base", "back_hanging_paw",
+    "right_ear_end", "front_right_thigh", "front_left_paw", "front_right_paw",
+    "left_ear_end", "front_right_elbow", "back_end", "front_left_elbow",
+    "back_hanging_knee", "back_on_track_thigh", "back_base", "back_hanging_thigh",
+    "back_middle", "tail_end", "tail_base", "front_left_thigh", "back_on_track_knee",
+    "back_on_track_paw", "breast",
+]
+assert len(PIG_TEMPLATE_LABELS) == 24
+
+
+def dto_to_nodes(dto: PredictionKeypoints) -> List[sly.Node]:
+    """Mirrors the PredictionKeypoints branch of YOLOv8Model._create_label
+    (serve/src/yolov8.py) exactly, without importing that module."""
+    disabled_flags: Optional[List[bool]] = getattr(dto, "disabled", None)
+    nodes = []
+    for i, (node_label, coordinate) in enumerate(zip(dto.labels, dto.coordinates)):
+        x, y = coordinate
+        is_disabled = bool(disabled_flags[i]) if disabled_flags is not None else False
+        nodes.append(sly.Node(label=node_label, row=y, col=x, disabled=is_disabled))
+    return nodes
+
+
+def make_full_pig_meta():
+    template = sly.geometry.graph.KeypointsTemplate()
+    for i, label in enumerate(PIG_TEMPLATE_LABELS):
+        template.add_point(label=label, row=i, col=i)
+    obj_class = sly.ObjClass(
+        "new pig on track keypoints", sly.GraphNodes, geometry_config=template
+    )
+    return sly.ProjectMeta(obj_classes=[obj_class]), obj_class
+
+
+def test_legacy_dto_without_disabled_attr_builds_all_visible_nodes():
+    """A DTO with no `.disabled` attribute (i.e. every other DTO producer in the
+    codebase, and this DTO before this feature existed) must behave exactly as before:
+    all constructed nodes are enabled."""
+    dto = PredictionKeypoints(
+        "new pig on track keypoints",
+        PIG_TEMPLATE_LABELS[:3],
+        [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)],
+    )
+    nodes = dto_to_nodes(dto)
+    assert len(nodes) == 3
+    assert all(not n.disabled for n in nodes)
+
+
+def test_dto_with_disabled_list_produces_matching_disabled_nodes():
+    labels = PIG_TEMPLATE_LABELS[:4]
+    coords = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0)]
+    disabled = [False, True, False, True]
+    dto = PredictionKeypoints("new pig on track keypoints", labels, coords)
+    dto.disabled = disabled
+    nodes = dto_to_nodes(dto)
+    assert [n.disabled for n in nodes] == disabled
+    # disabled nodes still carry a real location, same as a manually Ctrl-hidden point
+    assert [(n.location.row, n.location.col) for n in nodes] == [
+        (y, x) for x, y in coords
+    ]
+
+
+def test_all_24_nodes_present_with_mixed_disabled_validates_against_full_template():
+    """This is the customer's exact ask: keep_all_keypoints=True should produce a
+    label with all 24 template nodes (some disabled), and it must validate cleanly
+    against a project meta that declares all 24 -- no
+    "Graph contains nodes not declared in the template" error."""
+    meta, obj_class = make_full_pig_meta()
+    coords = [(float(i), float(i)) for i in range(24)]
+    # simulate: first 10 keypoints confidently detected, remaining 14 below threshold
+    disabled = [False] * 10 + [True] * 14
+    dto = PredictionKeypoints("new pig on track keypoints", PIG_TEMPLATE_LABELS, coords)
+    dto.disabled = disabled
+    nodes = dto_to_nodes(dto)
+    assert len(nodes) == 24
+
+    # Label.__init__ validates the geometry against obj_class.geometry_config
+    # internally -- it must NOT raise "Graph contains nodes not declared in
+    # the template" here, unlike the original customer-reported bug.
+    label = sly.Label(sly.GraphNodes(nodes), obj_class)
+
+    geometry_json = label.geometry.to_json()
+    assert set(geometry_json["nodes"].keys()) == set(PIG_TEMPLATE_LABELS)
+    disabled_in_json = {
+        lbl for lbl, node in geometry_json["nodes"].items() if node.get("disabled")
+    }
+    assert disabled_in_json == set(PIG_TEMPLATE_LABELS[10:])
+
+
+def test_default_partial_label_also_validates_against_full_template():
+    """Regression guard: today's default behavior (drop sub-threshold points, so
+    fewer than 24 nodes are present) must keep validating fine too -- a label using a
+    subset of a template's nodes is always valid; validate() only rejects nodes that
+    are NOT declared in the template."""
+    meta, obj_class = make_full_pig_meta()
+    labels = PIG_TEMPLATE_LABELS[:5]
+    coords = [(float(i), float(i)) for i in range(5)]
+    dto = PredictionKeypoints("new pig on track keypoints", labels, coords)
+    nodes = dto_to_nodes(dto)
+    assert len(nodes) == 5
+
+    label = sly.Label(sly.GraphNodes(nodes), obj_class)  # must not raise
+
+    geometry_json = label.geometry.to_json()
+    assert set(geometry_json["nodes"].keys()) == set(labels)
+    assert not any(node.get("disabled") for node in geometry_json["nodes"].values())
+
+
+def test_disabled_flag_round_trips_through_json_like_a_manual_annotation():
+    """Node.to_json only writes "disabled" when True (see supervisely/geometry/graph.py);
+    a manually Ctrl-hidden keypoint is stored the same way. Confirms our nodes are
+    indistinguishable from a manually annotated disabled node after round-tripping."""
+    node_visible = sly.Node(label="breast", row=1, col=1, disabled=False)
+    node_hidden = sly.Node(label="tail_end", row=2, col=2, disabled=True)
+
+    visible_json = node_visible.to_json()
+    hidden_json = node_hidden.to_json()
+    assert "disabled" not in visible_json
+    assert hidden_json["disabled"] is True
+
+    restored_visible = sly.geometry.graph.Node.from_json(visible_json)
+    restored_hidden = sly.geometry.graph.Node.from_json(hidden_json)
+    assert restored_visible.disabled is False
+    assert restored_hidden.disabled is True
+
+
+def test_disabled_count_below_two_visible_would_have_skipped_instance_pre_feature():
+    """Sanity-check for the count_visible() gate used in yolov8.py: an instance with
+    zero or one confident point should not have produced a keypoints annotation
+    before this feature, and with keep_all_keypoints=True it must still be gated the
+    same way (based on *visible* count, not total node count)."""
+    from src.keypoints_confidence import count_visible
+
+    all_disabled_but_one = [True] * 23 + [False]
+    assert count_visible(all_disabled_but_one) == 1  # still gated out (needs > 1)
+
+    two_visible = [True] * 22 + [False, False]
+    assert count_visible(two_visible) == 2  # gated in

--- a/tests/test_keep_all_keypoints_label.py
+++ b/tests/test_keep_all_keypoints_label.py
@@ -35,12 +35,14 @@ assert len(PIG_TEMPLATE_LABELS) == 24
 
 def dto_to_nodes(dto: PredictionKeypoints) -> List[sly.Node]:
     """Mirrors the PredictionKeypoints branch of YOLOv8Model._create_label
-    (serve/src/yolov8.py) exactly, without importing that module."""
-    disabled_flags: Optional[List[bool]] = getattr(dto, "disabled", None)
+    (serve/src/yolov8.py) exactly, without importing that module. Bounds-safe on
+    purpose: a `.disabled` list shorter than `.labels`/`.coordinates` must not raise,
+    it should just default the missing entries to enabled."""
+    disabled_flags: Optional[List[bool]] = getattr(dto, "disabled", None) or []
     nodes = []
     for i, (node_label, coordinate) in enumerate(zip(dto.labels, dto.coordinates)):
         x, y = coordinate
-        is_disabled = bool(disabled_flags[i]) if disabled_flags is not None else False
+        is_disabled = bool(disabled_flags[i]) if i < len(disabled_flags) else False
         nodes.append(sly.Node(label=node_label, row=y, col=x, disabled=is_disabled))
     return nodes
 
@@ -145,6 +147,29 @@ def test_disabled_flag_round_trips_through_json_like_a_manual_annotation():
     restored_hidden = sly.geometry.graph.Node.from_json(hidden_json)
     assert restored_visible.disabled is False
     assert restored_hidden.disabled is True
+
+
+def test_disabled_list_shorter_than_labels_does_not_crash():
+    """Defensive guard: if `.disabled` is ever malformed (too short) relative to
+    `.labels`/`.coordinates`, building nodes must not raise -- missing entries
+    default to enabled rather than throwing IndexError."""
+    labels = PIG_TEMPLATE_LABELS[:5]
+    coords = [(float(i), float(i)) for i in range(5)]
+    dto = PredictionKeypoints("new pig on track keypoints", labels, coords)
+    dto.disabled = [True]  # only 1 entry for 5 labels
+    nodes = dto_to_nodes(dto)  # must not raise
+    assert len(nodes) == 5
+    assert [n.disabled for n in nodes] == [True, False, False, False, False]
+
+
+def test_disabled_explicitly_none_or_empty_behaves_like_missing():
+    labels = PIG_TEMPLATE_LABELS[:2]
+    coords = [(1.0, 1.0), (2.0, 2.0)]
+    for disabled_value in (None, []):
+        dto = PredictionKeypoints("new pig on track keypoints", labels, coords)
+        dto.disabled = disabled_value
+        nodes = dto_to_nodes(dto)  # must not raise
+        assert [n.disabled for n in nodes] == [False, False]
 
 
 def test_disabled_count_below_two_visible_would_have_skipped_instance_pre_feature():

--- a/tests/test_keypoints_confidence.py
+++ b/tests/test_keypoints_confidence.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for src.keypoints_confidence — the pure post-processing logic behind the
+Serve YOLO "keep_all_keypoints" setting.
+
+Deliberately dependency-light (stdlib only): does not import yolov8.py, ultralytics,
+torch, cv2 or supervisely, so it can run in any Python environment without setting up
+the full serve app stack.
+
+Run with:  python -m pytest tests/test_keypoints_confidence.py -v
+(from the repo root, with "serve" on sys.path — see conftest.py)
+"""
+
+import pytest
+
+from src.keypoints_confidence import count_visible, split_keypoints_by_confidence
+
+LABELS = ["nose_end", "back_base", "front_right_elbow", "belly_bottom", "breast"]
+COORDS = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), (5.0, 5.0)]
+
+
+def test_all_above_threshold_are_included_and_enabled():
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, [0.9, 0.8, 0.95, 0.5, 0.6], point_threshold=0.1, keep_all_keypoints=False
+    )
+    assert labels == LABELS
+    assert coords == COORDS
+    assert disabled == [False] * len(LABELS)
+
+
+def test_default_behavior_drops_low_confidence_points_unchanged():
+    """keep_all_keypoints=False must reproduce the pre-existing behavior exactly:
+    sub-threshold points are dropped, not retained as disabled."""
+    scores = [0.9, 0.05, 0.95, 0.02, 0.6]
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=False
+    )
+    assert labels == ["nose_end", "front_right_elbow", "breast"]
+    assert coords == [(1.0, 1.0), (3.0, 3.0), (5.0, 5.0)]
+    assert disabled == [False, False, False]
+
+
+def test_keep_all_keypoints_marks_low_confidence_points_disabled_instead_of_dropping():
+    scores = [0.9, 0.05, 0.95, 0.02, 0.6]
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    )
+    # all 24 (here: 5) labels are always present, in the original order
+    assert labels == LABELS
+    assert coords == COORDS
+    assert disabled == [False, True, False, True, False]
+
+
+def test_keep_all_keypoints_with_all_points_confident_has_none_disabled():
+    scores = [0.9, 0.8, 0.95, 0.5, 0.6]
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    )
+    assert labels == LABELS
+    assert disabled == [False] * len(LABELS)
+
+
+def test_keep_all_keypoints_with_all_points_unconfident_marks_all_disabled():
+    scores = [0.0, 0.01, 0.02, 0.0, 0.09]
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    )
+    assert labels == LABELS
+    assert coords == COORDS
+    assert disabled == [True] * len(LABELS)
+
+
+def test_without_keep_all_keypoints_all_points_unconfident_yields_nothing():
+    scores = [0.0, 0.01, 0.02, 0.0, 0.09]
+    labels, coords, disabled = split_keypoints_by_confidence(
+        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=False
+    )
+    assert labels == []
+    assert coords == []
+    assert disabled == []
+
+
+@pytest.mark.parametrize("keep_all_keypoints", [False, True])
+def test_score_exactly_at_threshold_counts_as_visible(keep_all_keypoints):
+    # ">= point_threshold" -> a point exactly at the threshold is confident/enabled,
+    # regardless of keep_all_keypoints
+    labels, coords, disabled = split_keypoints_by_confidence(
+        ["a"], [(0.0, 0.0)], [0.1], point_threshold=0.1, keep_all_keypoints=keep_all_keypoints
+    )
+    assert labels == ["a"]
+    assert disabled == [False]
+
+
+def test_empty_input_returns_empty_lists():
+    labels, coords, disabled = split_keypoints_by_confidence(
+        [], [], [], point_threshold=0.1, keep_all_keypoints=True
+    )
+    assert (labels, coords, disabled) == ([], [], [])
+
+
+def test_output_lists_are_always_same_length_as_each_other():
+    for keep_all_keypoints in (False, True):
+        labels, coords, disabled = split_keypoints_by_confidence(
+            LABELS, COORDS, [0.9, 0.05, 0.95, 0.02, 0.6], 0.1, keep_all_keypoints
+        )
+        assert len(labels) == len(coords) == len(disabled)
+
+
+def test_count_visible():
+    assert count_visible([]) == 0
+    assert count_visible([False, False, False]) == 3
+    assert count_visible([True, True, True]) == 0
+    assert count_visible([False, True, False, True, True]) == 2

--- a/tests/test_keypoints_confidence.py
+++ b/tests/test_keypoints_confidence.py
@@ -12,70 +12,61 @@ Run with:  python -m pytest tests/test_keypoints_confidence.py -v
 
 import pytest
 
-from src.keypoints_confidence import count_visible, split_keypoints_by_confidence
+from src.keypoints_confidence import count_visible, select_visible_indices
 
-LABELS = ["nose_end", "back_base", "front_right_elbow", "belly_bottom", "breast"]
-COORDS = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0), (4.0, 4.0), (5.0, 5.0)]
+SCORES = [0.9, 0.05, 0.95, 0.02, 0.6]
 
 
 def test_all_above_threshold_are_included_and_enabled():
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, [0.9, 0.8, 0.95, 0.5, 0.6], point_threshold=0.1, keep_all_keypoints=False
+    indices, disabled = select_visible_indices(
+        [0.9, 0.8, 0.95, 0.5, 0.6], point_threshold=0.1, keep_all_keypoints=False
     )
-    assert labels == LABELS
-    assert coords == COORDS
-    assert disabled == [False] * len(LABELS)
+    assert indices == [0, 1, 2, 3, 4]
+    assert disabled == [False] * 5
 
 
 def test_default_behavior_drops_low_confidence_points_unchanged():
     """keep_all_keypoints=False must reproduce the pre-existing behavior exactly:
     sub-threshold points are dropped, not retained as disabled."""
-    scores = [0.9, 0.05, 0.95, 0.02, 0.6]
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=False
+    indices, disabled = select_visible_indices(
+        SCORES, point_threshold=0.1, keep_all_keypoints=False
     )
-    assert labels == ["nose_end", "front_right_elbow", "breast"]
-    assert coords == [(1.0, 1.0), (3.0, 3.0), (5.0, 5.0)]
+    assert indices == [0, 2, 4]  # only the points scoring >= 0.1
     assert disabled == [False, False, False]
 
 
 def test_keep_all_keypoints_marks_low_confidence_points_disabled_instead_of_dropping():
-    scores = [0.9, 0.05, 0.95, 0.02, 0.6]
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    indices, disabled = select_visible_indices(
+        SCORES, point_threshold=0.1, keep_all_keypoints=True
     )
-    # all 24 (here: 5) labels are always present, in the original order
-    assert labels == LABELS
-    assert coords == COORDS
+    # every index is present, in original order
+    assert indices == [0, 1, 2, 3, 4]
     assert disabled == [False, True, False, True, False]
 
 
 def test_keep_all_keypoints_with_all_points_confident_has_none_disabled():
-    scores = [0.9, 0.8, 0.95, 0.5, 0.6]
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    indices, disabled = select_visible_indices(
+        [0.9, 0.8, 0.95, 0.5, 0.6], point_threshold=0.1, keep_all_keypoints=True
     )
-    assert labels == LABELS
-    assert disabled == [False] * len(LABELS)
+    assert indices == [0, 1, 2, 3, 4]
+    assert disabled == [False] * 5
 
 
 def test_keep_all_keypoints_with_all_points_unconfident_marks_all_disabled():
     scores = [0.0, 0.01, 0.02, 0.0, 0.09]
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=True
+    indices, disabled = select_visible_indices(
+        scores, point_threshold=0.1, keep_all_keypoints=True
     )
-    assert labels == LABELS
-    assert coords == COORDS
-    assert disabled == [True] * len(LABELS)
+    assert indices == [0, 1, 2, 3, 4]
+    assert disabled == [True] * 5
 
 
 def test_without_keep_all_keypoints_all_points_unconfident_yields_nothing():
     scores = [0.0, 0.01, 0.02, 0.0, 0.09]
-    labels, coords, disabled = split_keypoints_by_confidence(
-        LABELS, COORDS, scores, point_threshold=0.1, keep_all_keypoints=False
+    indices, disabled = select_visible_indices(
+        scores, point_threshold=0.1, keep_all_keypoints=False
     )
-    assert labels == []
-    assert coords == []
+    assert indices == []
     assert disabled == []
 
 
@@ -83,26 +74,32 @@ def test_without_keep_all_keypoints_all_points_unconfident_yields_nothing():
 def test_score_exactly_at_threshold_counts_as_visible(keep_all_keypoints):
     # ">= point_threshold" -> a point exactly at the threshold is confident/enabled,
     # regardless of keep_all_keypoints
-    labels, coords, disabled = split_keypoints_by_confidence(
-        ["a"], [(0.0, 0.0)], [0.1], point_threshold=0.1, keep_all_keypoints=keep_all_keypoints
+    indices, disabled = select_visible_indices(
+        [0.1], point_threshold=0.1, keep_all_keypoints=keep_all_keypoints
     )
-    assert labels == ["a"]
+    assert indices == [0]
     assert disabled == [False]
 
 
 def test_empty_input_returns_empty_lists():
-    labels, coords, disabled = split_keypoints_by_confidence(
-        [], [], [], point_threshold=0.1, keep_all_keypoints=True
+    indices, disabled = select_visible_indices(
+        [], point_threshold=0.1, keep_all_keypoints=True
     )
-    assert (labels, coords, disabled) == ([], [], [])
+    assert (indices, disabled) == ([], [])
 
 
 def test_output_lists_are_always_same_length_as_each_other():
     for keep_all_keypoints in (False, True):
-        labels, coords, disabled = split_keypoints_by_confidence(
-            LABELS, COORDS, [0.9, 0.05, 0.95, 0.02, 0.6], 0.1, keep_all_keypoints
-        )
-        assert len(labels) == len(coords) == len(disabled)
+        indices, disabled = select_visible_indices(SCORES, 0.1, keep_all_keypoints)
+        assert len(indices) == len(disabled)
+
+
+def test_indices_are_a_subset_in_ascending_original_order():
+    for keep_all_keypoints in (False, True):
+        indices, _ = select_visible_indices(SCORES, 0.1, keep_all_keypoints)
+        assert indices == sorted(indices)
+        assert len(set(indices)) == len(indices)  # no duplicates
+        assert all(0 <= i < len(SCORES) for i in indices)  # always in-bounds
 
 
 def test_count_visible():


### PR DESCRIPTION
Serve YOLO currently drops any pose keypoint scoring below point_threshold entirely, so predicted GraphNodes never contain the full template - unlike manually annotated data, where a not-visible keypoint stays in the graph as a disabled node (Ctrl-hidden) instead of being removed.

Add an opt-in "keep_all_keypoints" inference setting (default false, so existing behavior/users are unaffected): when enabled, every template keypoint is always emitted, and points below the confidence threshold are marked disabled instead of being dropped, matching manual annotation semantics.